### PR TITLE
Fix wrong ip message

### DIFF
--- a/simple-httpd.el
+++ b/simple-httpd.el
@@ -375,7 +375,7 @@ instance per Emacs instance."
   (httpd-start)
   (message "Started simple-httpd on %s:%d, serving: %s"
            (cl-case httpd-host
-             ((nil) "0.0.0.0")
+             ((nil) "127.0.0.1")
              ((local) "localhost")
              (otherwise httpd-host)) httpd-port directory))
 


### PR DESCRIPTION
`make-network-process` uses `"127.0.0.1"` when `:host` is `nil`.