### PR TITLE
add application/wasm mime type

### DIFF
--- a/simple-httpd.el
+++ b/simple-httpd.el
@@ -221,6 +221,7 @@
     ("pdf"  . "application/pdf")
     ("tar"  . "application/x-tar")
     ("zip"  . "application/zip")
+    ("wasm" . "application/wasm")
     ("mp3"  . "audio/mpeg")
     ("wav"  . "audio/x-wav")
     ("flac" . "audio/flac")


### PR DESCRIPTION
currently, trying to serve wasm causes the following errors to appear in the console:

Firefox:

`Uncaught (in promise) TypeError: WebAssembly: Response has unsupported MIME type '' expected 'application/wasm'`
 
Chrome:

`Uncaught (in promise) TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.`

this change fixes that